### PR TITLE
build: Use smaller mega linter image in CI

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -51,7 +51,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://oxsecurity.github.io/megalinter/flavors/
-        uses: oxsecurity/megalinter@v6
+        uses: oxsecurity/megalinter/flavors/cupcake@beta
         env:
           # All available variables are described in documentation
           # https://oxsecurity.github.io/megalinter/configuration/


### PR DESCRIPTION
Uses a smaller mega linter image in the CI: [cupcake](https://github.com/oxsecurity/megalinter/blob/main/docs/flavors/cupcake.md), which contains only the most popular linters. The image is about half the size of the image we were previously using. This cuts the download time down by about 30 seconds.