### PR TITLE
fix: correct `AUTH0_DOMAIN` environment variable

### DIFF
--- a/python-package/src/opchatserver/authorization.py
+++ b/python-package/src/opchatserver/authorization.py
@@ -19,7 +19,7 @@ class VerifyToken:
     https://auth0.com/blog/build-and-secure-fastapi-server-with-auth0/
     """
 
-    domain = os.environ.get("AUTH0DOMAIN")
+    domain = os.environ.get("AUTH0_DOMAIN")
     audience = os.environ.get("AUTH0_API_AUDIENCE")
     algorithms = ["RS256"]
 


### PR DESCRIPTION
Fixes a bug from #33 that incorrectly spelled the `AUTH0_DOMAIN` environment variable