### PR TITLE
build: use upstream langchain

### DIFF
--- a/python-package/requirements.txt
+++ b/python-package/requirements.txt
@@ -5,7 +5,7 @@ pyjwt==2.8.0
 python-jose==3.3.0
 requests==2.31.0
 uvicorn[standard]==0.23.2
-langchain@git+https://github.com/opaque-systems/langchain.git@rename_and_args#subdirectory=libs/langchain
+langchain
 opaqueprompts
 prometheus-client
 openai

--- a/python-package/requirements.txt
+++ b/python-package/requirements.txt
@@ -5,7 +5,7 @@ pyjwt==2.8.0
 python-jose==3.3.0
 requests==2.31.0
 uvicorn[standard]==0.23.2
-langchain
-opaqueprompts
-prometheus-client
-openai
+langchain==0.0.279
+opaqueprompts==0.0.4
+prometheus-client==0.17.1
+openai==0.28.0


### PR DESCRIPTION
We can use the upstream langchain as the change is merged and new version is published.