### PR TITLE
docs: Add link to LangChain docs in code

### DIFF
--- a/python-package/src/opchatserver/server.py
+++ b/python-package/src/opchatserver/server.py
@@ -112,6 +112,9 @@ async def chat(
         # This is the typical case for the OpaquePrompts LangChain integration.
         # We can get security from OpaquePrompts by simply wrapping the LLM,
         # e.g. `llm=OpenAI()` -> `llm=OpaquePrompts(base_llm=OpenAI())`.
+        #
+        # More about the LangChain integration can be found here:
+        # https://python.langchain.com/docs/integrations/llms/opaqueprompts
         chain = LLMChain(
             prompt=prompt,
             llm=OpaquePrompts(base_llm=OpenAI()),


### PR DESCRIPTION
Add a link to the OpaquePrompts page in the LangChain docs, in our source code