### PR TITLE
Update LangChain version to 0.0.350

### DIFF
--- a/python-package/requirements.txt
+++ b/python-package/requirements.txt
@@ -5,7 +5,7 @@ pyjwt==2.8.0
 python-jose==3.3.0
 requests==2.31.0
 uvicorn[standard]==0.23.2
-langchain==0.0.279
+langchain==0.0.350
 opaqueprompts>=0.1.0
 prometheus-client==0.17.1
 openai==0.28.0


### PR DESCRIPTION
Update the LangChain version to 0.0.350. The `text-davinci-003` model that we're currently using in the chat server is getting deprecated in January 2024, so we need to upgrade to `gpt-3.5-turbo-instruct`. This model is only supported in LangChain 0.0.295 and later.